### PR TITLE
Add jsonpickle to setup.py as project requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,4 +71,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
+    install_requires=[
+        'jsonpickle==1.2',
+    ]
 )


### PR DESCRIPTION
Add project requirements to `install_requires` in setup.py for correct requirement resolving.

At this moment all package tools like pip, poetry, and pipenv failed if they tried to install redisbeat without explicit jsonpickle.