### PR TITLE
Modify schedule logging string

### DIFF
--- a/redisbeat/scheduler.py
+++ b/redisbeat/scheduler.py
@@ -68,7 +68,7 @@ class RedisScheduler(Scheduler):
         self.merge_inplace(self.app.conf.CELERYBEAT_SCHEDULE)
         tasks = [jsonpickle.decode(entry) for entry in self.rdb.zrange(self.key, 0, -1)]
         linfo('Current schedule:\n' + '\n'.join(
-              str('task: ' + entry.task + '; each: ' + entry.schedule.human_seconds)
+              str('task: ' + entry.task + '; each: ' + repr(entry.schedule))
               for entry in tasks))
 
     def merge_inplace(self, tasks):

--- a/redisbeat/scheduler.py
+++ b/redisbeat/scheduler.py
@@ -122,6 +122,18 @@ class RedisScheduler(Scheduler):
         else:
             return False
 
+    def list(self):
+        return [jsonpickle.decode(entry) for entry in self.rdb.zrange(self.key, 0, -1)]
+    
+    def get(self, task_key):
+        tasks = self.rdb.zrange(self.key, 0, -1) or []
+        for idx, task in enumerate(tasks):
+            entry = jsonpickle.decode(task)
+            if entry.name == task_key:
+                return entry
+        else:
+            return None
+        
     def tick(self):
         tasks = self.rdb.zrangebyscore(
             self.key, 0,


### PR DESCRIPTION
entry.schedule.human_seconds doesn't work with crontab since it doesn't have human_seconds field
Instead use repr(entry.schedule).
repr() is implemented for every schedule type in celery.
For exemple, for crontab, it writes : "<crontab: * * * * * (m/h/d/dM/MY)>"