### PR TITLE
Upgrade to Celery 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ app = Celery('tasks', backend='redis://redis:6379',
                 broker='redis://redis:6379')
 
 app.conf.update(
-    CELERY_REDIS_SCHEDULER_URL = 'redis://redis:6379',
+    redis_scheduler_url = 'redis://redis:6379',
 #(...)
 ```
 
@@ -98,7 +98,7 @@ app = Celery('tasks', backend='redis://localhost:6379',
              broker='redis://localhost:6379')
 
 app.conf.update(
-    CELERYBEAT_SCHEDULE={
+    beat_schedule={
         'perminute': {
             'task': 'tasks.add',
             'schedule': timedelta(seconds=3),
@@ -130,7 +130,7 @@ app = Celery('tasks', backend='redis://localhost:6379',
              broker='redis://localhost:6379')
 
 app.conf.update(
-    CELERYBEAT_SCHEDULE={
+    beat_schedule={
         'perminute': {
             'task': 'tasks.add',
             'schedule': timedelta(seconds=3),
@@ -166,10 +166,10 @@ It can be easily to add task for two step:
 Or you can define settings in your celery configuration file similar to other configurations.
 
 ```python
-CELERY_BEAT_SCHEDULER = 'redisbeat.RedisScheduler'
-CELERY_REDIS_SCHEDULER_URL = 'redis://localhost:6379/1'
-CELERY_REDIS_SCHEDULER_KEY = 'celery:beat:order_tasks'
-CELERYBEAT_SCHEDULE = {
+beat_scheduler = 'redisbeat.RedisScheduler'
+redis_scheduler_url = 'redis://localhost:6379/1'
+redis_scheduler_key = 'celery:beat:order_tasks'
+beat_schedule = {
     'perminute': {
         'task': 'tasks.add',
         'schedule': timedelta(seconds=3),
@@ -183,10 +183,10 @@ CELERYBEAT_SCHEDULE = {
 For running `redisbeat` in multi node deployment, it uses redis lock to prevent same task to be executed mutiple times.
 
 ```python
-CELERY_REDIS_MULTI_NODE_MODE = True
-CELERY_REDIS_SCHEDULER_LOCK_TTL = 30
+redis_multi_node_mode = True
+redis_scheduler_lock_ttl = 30
 ```
 
-This is an experimental feature, to use `redisbeat` in production env, set `CELERY_REDIS_MULTI_NODE_MODE = False`, `redisbeat` will not use this feature.
+This is an experimental feature, to use `redisbeat` in production env, set `redis_multi_node_mode = False`, `redisbeat` will not use this feature.
 
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     restart: unless-stopped
     build:
       context: .
-    command: ["celery", "worker", "-A", "tasks", "-l", "INFO"]
+    command: ["celery", "-A", "tasks", "worker", "-l", "INFO"]
     depends_on:
-      - redis    
+      - redis
     stdin_open: true
     tty: true
 
@@ -20,7 +20,7 @@ services:
     restart: unless-stopped
     build:
       context: .
-    command: ["celery", "beat", "-A", "tasks",
+    command: ["celery", "-A", "tasks", "beat",
               "-S", "redisbeat.RedisScheduler", "-l", "INFO"]
     depends_on:
       - worker

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,6 +1,5 @@
 amqp==2.5.1
 billiard==3.6.1.0
-celery==4.3.0
 kombu==4.6.3
 pytz==2019.2
 redis==3.3.8

--- a/example/tasks.py
+++ b/example/tasks.py
@@ -8,8 +8,8 @@ app = Celery('tasks', backend='redis://redis:6379',
              broker='redis://redis:6379')
 
 app.conf.update(
-    CELERY_REDIS_SCHEDULER_URL = 'redis://redis:6379',
-    CELERYBEAT_SCHEDULE={
+    redis_scheduler_url = 'redis://redis:6379',
+    beat_schedule = {
         'perminute': {
             'task': 'tasks.add',
             'schedule': timedelta(seconds=3),

--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,6 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'jsonpickle==1.2',
+        'celery>=5'
     ]
 )

--- a/test/celeryconfig.py
+++ b/test/celeryconfig.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
-CELERY_REDIS_SCHEDULER_URL = "redis://localhost:6379/0"
-BROKER_URL = "redis://localhost:6379/0"
-CELERY_REDIS_SCHEDULER_KEY_PREFIX = 'tasks:meta:'
-CELERYBEAT_SCHEDULE = {
+redis_scheduler_url = "redis://localhost:6379/0"
+broker_url = "redis://localhost:6379/0"
+redis_scheduler_key_prefix = 'tasks:meta:'
+beat_schedule = {
     'add-every-3-seconds': {
         'task': 'tasks.add',
         'schedule': timedelta(seconds=3),


### PR DESCRIPTION
Celery 5 has some backward incompatibilities, [listed here](https://docs.celeryq.dev/en/stable/history/whatsnew-5.0.html). Namely

- Settings have changed name and are now lowercase by convention.
- Command line arguments have changed

This PR introduces those changes, and adds a restriction so that these changes aren't used in not compatible environments.