### PR TITLE
Bump jsonpickle to 3.3.0 to add support till python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'jsonpickle==1.4.2',
+        'jsonpickle==3.0.0',
     ]
 )


### PR DESCRIPTION
Bump jsonpickle to 3.3.0 to add support to newer python till 3.11.

It don't make redisbeat support 3.12/3.13 yet, since the legacy 'setup.py install' method is used on the library and distutils was removed since Python 3.12.

With Python 3.11 and jsonpickle==3.3.0 all the tests passed and I could use the Scheduler correctly with celery==5.4.0 and redis==3.5.3 (latest versions at the moment)