### PR TITLE
Fix #43 Add Redis Cluster support

### DIFF
--- a/example/cluster/Dockerfile
+++ b/example/cluster/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-alpine
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY tasks.py add_task.py ./

--- a/example/cluster/Dockerfile
+++ b/example/cluster/Dockerfile
@@ -1,7 +1,15 @@
 FROM python:3.11-alpine
 WORKDIR /usr/src/app
 
-COPY requirements.txt ./
+# Build context is the repository root (see docker-compose.yml) so we can
+# install redisbeat directly from local source — the rediscluster:// support
+# is not on PyPI yet.
+
+COPY example/cluster/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY tasks.py add_task.py ./
+COPY setup.py /usr/src/redisbeat/
+COPY redisbeat /usr/src/redisbeat/redisbeat
+RUN pip install --no-cache-dir --no-deps /usr/src/redisbeat
+
+COPY example/cluster/tasks.py example/cluster/add_task.py ./

--- a/example/cluster/add_task.py
+++ b/example/cluster/add_task.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""Smoke test: connect to the Redis Cluster via redisbeat and register a task.
+
+Run from inside the worker/beat container, e.g.:
+    docker compose run --rm beat python add_task.py
+"""
+from datetime import timedelta
+import logging
+import sys
+
+from redisbeat.scheduler import RedisScheduler
+
+from tasks import app
+
+
+root = logging.getLogger()
+root.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+handler.setFormatter(logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+root.addHandler(handler)
+
+
+if __name__ == "__main__":
+    scheduler = RedisScheduler(app=app, skip_init=True)
+    scheduler.add(**{
+        'name': 'sub-every-5-seconds',
+        'task': 'tasks.sub',
+        'schedule': timedelta(seconds=5),
+        'args': (2, 1),
+    })
+    print("task registered on cluster")

--- a/example/cluster/docker-compose.yml
+++ b/example/cluster/docker-compose.yml
@@ -84,7 +84,8 @@ services:
 
   worker:
     build:
-      context: .
+      context: ../..
+      dockerfile: example/cluster/Dockerfile
     command: ["celery", "-A", "tasks", "worker", "-l", "INFO"]
     depends_on:
       - broker
@@ -95,7 +96,8 @@ services:
 
   beat:
     build:
-      context: .
+      context: ../..
+      dockerfile: example/cluster/Dockerfile
     command:
       ["celery", "-A", "tasks", "beat", "-S", "redisbeat.RedisScheduler", "-l", "INFO"]
     depends_on:

--- a/example/cluster/docker-compose.yml
+++ b/example/cluster/docker-compose.yml
@@ -1,0 +1,113 @@
+# Redis Cluster example for redisbeat.
+#
+# Layout:
+#   - 6 redis-cluster nodes (3 masters + 3 replicas, Bitnami image).
+#   - One init container that bootstraps the cluster on first boot.
+#   - A standalone redis used as the Celery broker/backend
+#     (kombu / celery-redis does not speak the cluster protocol, so the
+#      broker is kept separate; only redisbeat's schedule storage uses
+#      the cluster).
+#   - worker + beat. Beat is configured with rediscluster:// so the
+#     SELECT-in-cluster-mode error from issue #43 no longer triggers.
+#
+# Run:
+#   docker compose up --build
+#
+# To re-bootstrap the cluster from scratch, also remove the volumes:
+#   docker compose down -v
+
+version: '3.8'
+
+x-redis-cluster-env: &redis-cluster-env
+  ALLOW_EMPTY_PASSWORD: "yes"
+  REDIS_NODES: "redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5"
+
+services:
+  redis-node-0:
+    image: docker.io/bitnami/redis-cluster:7.2
+    environment:
+      <<: *redis-cluster-env
+    volumes:
+      - redis-cluster_data-0:/bitnami/redis/data
+
+  redis-node-1:
+    image: docker.io/bitnami/redis-cluster:7.2
+    environment:
+      <<: *redis-cluster-env
+    volumes:
+      - redis-cluster_data-1:/bitnami/redis/data
+
+  redis-node-2:
+    image: docker.io/bitnami/redis-cluster:7.2
+    environment:
+      <<: *redis-cluster-env
+    volumes:
+      - redis-cluster_data-2:/bitnami/redis/data
+
+  redis-node-3:
+    image: docker.io/bitnami/redis-cluster:7.2
+    environment:
+      <<: *redis-cluster-env
+    volumes:
+      - redis-cluster_data-3:/bitnami/redis/data
+
+  redis-node-4:
+    image: docker.io/bitnami/redis-cluster:7.2
+    environment:
+      <<: *redis-cluster-env
+    volumes:
+      - redis-cluster_data-4:/bitnami/redis/data
+
+  redis-node-5:
+    image: docker.io/bitnami/redis-cluster:7.2
+    depends_on:
+      - redis-node-0
+      - redis-node-1
+      - redis-node-2
+      - redis-node-3
+      - redis-node-4
+    environment:
+      <<: *redis-cluster-env
+      REDIS_CLUSTER_REPLICAS: "1"
+      REDIS_CLUSTER_CREATOR: "yes"
+    volumes:
+      - redis-cluster_data-5:/bitnami/redis/data
+
+  # Standalone redis for celery broker/backend (cluster as a broker is not
+  # supported by kombu).
+  broker:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: .
+    command: ["celery", "-A", "tasks", "worker", "-l", "INFO"]
+    depends_on:
+      - broker
+      - redis-node-5
+    environment:
+      CELERY_BROKER_URL: "redis://broker:6379/0"
+      CELERY_RESULT_BACKEND: "redis://broker:6379/0"
+
+  beat:
+    build:
+      context: .
+    command:
+      ["celery", "-A", "tasks", "beat", "-S", "redisbeat.RedisScheduler", "-l", "INFO"]
+    depends_on:
+      - worker
+      - redis-node-5
+    environment:
+      CELERY_BROKER_URL: "redis://broker:6379/0"
+      CELERY_RESULT_BACKEND: "redis://broker:6379/0"
+      # redisbeat schedule storage lives in the Redis Cluster.
+      CELERY_REDIS_SCHEDULER_URL: "rediscluster://redis-node-0:6379,redis-node-1:6379,redis-node-2:6379"
+
+volumes:
+  redis-cluster_data-0:
+  redis-cluster_data-1:
+  redis-cluster_data-2:
+  redis-cluster_data-3:
+  redis-cluster_data-4:
+  redis-cluster_data-5:

--- a/example/cluster/docker-compose.yml
+++ b/example/cluster/docker-compose.yml
@@ -32,6 +32,15 @@ services:
       <<: *redis-cluster-env
     volumes:
       - redis-cluster_data-0:/bitnami/redis/data
+    # Probes the cluster-wide state. Once redis-node-5 finishes the
+    # `redis-cli --cluster create` bootstrap, every node returns
+    # cluster_state:ok and dependent services may safely start.
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -p 6379 cluster info | grep -q cluster_state:ok"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
 
   redis-node-1:
     image: docker.io/bitnamilegacy/redis-cluster:7.4
@@ -88,8 +97,10 @@ services:
       dockerfile: example/cluster/Dockerfile
     command: ["celery", "-A", "tasks", "worker", "-l", "INFO"]
     depends_on:
-      - broker
-      - redis-node-5
+      broker:
+        condition: service_started
+      redis-node-0:
+        condition: service_healthy
     environment:
       CELERY_BROKER_URL: "redis://broker:6379/0"
       CELERY_RESULT_BACKEND: "redis://broker:6379/0"
@@ -101,8 +112,10 @@ services:
     command:
       ["celery", "-A", "tasks", "beat", "-S", "redisbeat.RedisScheduler", "-l", "INFO"]
     depends_on:
-      - worker
-      - redis-node-5
+      worker:
+        condition: service_started
+      redis-node-0:
+        condition: service_healthy
     environment:
       CELERY_BROKER_URL: "redis://broker:6379/0"
       CELERY_RESULT_BACKEND: "redis://broker:6379/0"

--- a/example/cluster/docker-compose.yml
+++ b/example/cluster/docker-compose.yml
@@ -15,8 +15,11 @@
 #
 # To re-bootstrap the cluster from scratch, also remove the volumes:
 #   docker compose down -v
-
-version: '3.8'
+#
+# Note on the image: Bitnami moved community redis-cluster builds to the
+# bitnamilegacy/* namespace in Aug 2025; the original bitnami/redis-cluster
+# repo no longer publishes free tags. bitnamilegacy/redis-cluster:7.4 is the
+# closest drop-in.
 
 x-redis-cluster-env: &redis-cluster-env
   ALLOW_EMPTY_PASSWORD: "yes"
@@ -24,42 +27,42 @@ x-redis-cluster-env: &redis-cluster-env
 
 services:
   redis-node-0:
-    image: docker.io/bitnami/redis-cluster:7.2
+    image: docker.io/bitnamilegacy/redis-cluster:7.4
     environment:
       <<: *redis-cluster-env
     volumes:
       - redis-cluster_data-0:/bitnami/redis/data
 
   redis-node-1:
-    image: docker.io/bitnami/redis-cluster:7.2
+    image: docker.io/bitnamilegacy/redis-cluster:7.4
     environment:
       <<: *redis-cluster-env
     volumes:
       - redis-cluster_data-1:/bitnami/redis/data
 
   redis-node-2:
-    image: docker.io/bitnami/redis-cluster:7.2
+    image: docker.io/bitnamilegacy/redis-cluster:7.4
     environment:
       <<: *redis-cluster-env
     volumes:
       - redis-cluster_data-2:/bitnami/redis/data
 
   redis-node-3:
-    image: docker.io/bitnami/redis-cluster:7.2
+    image: docker.io/bitnamilegacy/redis-cluster:7.4
     environment:
       <<: *redis-cluster-env
     volumes:
       - redis-cluster_data-3:/bitnami/redis/data
 
   redis-node-4:
-    image: docker.io/bitnami/redis-cluster:7.2
+    image: docker.io/bitnamilegacy/redis-cluster:7.4
     environment:
       <<: *redis-cluster-env
     volumes:
       - redis-cluster_data-4:/bitnami/redis/data
 
   redis-node-5:
-    image: docker.io/bitnami/redis-cluster:7.2
+    image: docker.io/bitnamilegacy/redis-cluster:7.4
     depends_on:
       - redis-node-0
       - redis-node-1

--- a/example/cluster/requirements.txt
+++ b/example/cluster/requirements.txt
@@ -1,4 +1,5 @@
 celery>=5.3,<6
 redis>=4.1
 jsonpickle==3.3.0
-redisbeat
+# redisbeat itself is installed from local source in the Dockerfile,
+# because the rediscluster:// support is not on PyPI yet.

--- a/example/cluster/requirements.txt
+++ b/example/cluster/requirements.txt
@@ -1,0 +1,4 @@
+celery>=5.3,<6
+redis>=4.1
+jsonpickle==3.3.0
+redisbeat

--- a/example/cluster/tasks.py
+++ b/example/cluster/tasks.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""Celery app wired to a Redis Cluster for redisbeat scheduling.
+
+Env vars (set by docker-compose.yml):
+  CELERY_BROKER_URL           standalone redis used as broker/backend
+  CELERY_RESULT_BACKEND       standalone redis used as result backend
+  CELERY_REDIS_SCHEDULER_URL  rediscluster:// URL for redisbeat
+"""
+from datetime import timedelta
+import os
+
+from celery import Celery
+
+
+broker_url = os.environ.get('CELERY_BROKER_URL', 'redis://broker:6379/0')
+result_backend = os.environ.get('CELERY_RESULT_BACKEND', broker_url)
+scheduler_url = os.environ.get(
+    'CELERY_REDIS_SCHEDULER_URL',
+    'rediscluster://redis-node-0:6379,redis-node-1:6379,redis-node-2:6379',
+)
+
+app = Celery('tasks', backend=result_backend, broker=broker_url)
+
+app.conf.update(
+    CELERY_REDIS_SCHEDULER_URL=scheduler_url,
+    CELERYBEAT_SCHEDULE={
+        'every-3-seconds': {
+            'task': 'tasks.add',
+            'schedule': timedelta(seconds=3),
+            'args': (1, 1),
+        },
+    },
+)
+
+
+@app.task
+def add(x, y):
+    return x + y
+
+
+@app.task
+def sub(x, y):
+    return x - y

--- a/redisbeat/scheduler.py
+++ b/redisbeat/scheduler.py
@@ -101,6 +101,11 @@ class RedisScheduler(Scheduler):
             self.broker_transport_options = app.conf.get(BROKER_TRANSPORT_OPTIONS, default_transport_options)
             self.rdb = self.sentinel_connect(
                 self.broker_transport_options['master_name'])
+        elif self.schedule_url.startswith('rediscluster://'):
+            # Redis Cluster: SELECT is not supported, so any db component in
+            # the URL is ignored. Format:
+            #   rediscluster://[[user]:password@]host1:port1[,host2:port2,...]
+            self.rdb = self.cluster_connect()
         else:
             self.rdb = StrictRedis.from_url(self.schedule_url)
         Scheduler.__init__(self, *args, **kwargs)
@@ -289,6 +294,69 @@ class RedisScheduler(Scheduler):
             except LockError:
                 pass
         self.sync()
+
+    def cluster_connect(self):
+        """Connect to a Redis Cluster.
+
+        Supported URL format::
+
+            rediscluster://[[user]:password@]host1:port1[,host2:port2,...]
+
+        Notes:
+        - Cluster only supports DB 0; any path component in the URL is ignored.
+        - Requires redis-py >= 4.1, which ships ``redis.cluster.RedisCluster``.
+        """
+        try:
+            from redis.cluster import RedisCluster, ClusterNode
+        except ImportError as exc:
+            raise ImportError(
+                "Redis Cluster support requires redis-py>=4.1; "
+                "install with `pip install 'redis>=4.1'`."
+            )
+
+        url = urlparse.urlparse(self.schedule_url)
+
+        if '@' in url.netloc:
+            auth, hostspec = url.netloc.split('@', 1)
+        else:
+            auth = None
+            hostspec = url.netloc
+
+        username = None
+        password = None
+        if auth:
+            if ':' in auth:
+                username, password = auth.split(':', 1)
+                username = username or None
+                password = password or None
+            else:
+                password = auth
+
+        def _parse_host(s):
+            if ':' in s:
+                host, port = s.rsplit(':', 1)
+                port = int(port)
+            else:
+                host = s
+                port = 6379
+            return host, port
+
+        startup_nodes = [
+            ClusterNode(host, port)
+            for host, port in (_parse_host(s) for s in hostspec.split(',') if s)
+        ]
+        if not startup_nodes:
+            raise ValueError(
+                "rediscluster URL must include at least one host: %s"
+                % self.schedule_url)
+
+        kwargs = {}
+        if username is not None:
+            kwargs['username'] = username
+        if password is not None:
+            kwargs['password'] = password
+
+        return RedisCluster(startup_nodes=startup_nodes, **kwargs)
 
     def sentinel_connect(self, master_name):
         url = urlparse.urlparse(self.schedule_url)

--- a/t/unit/test_scheduler_cluster.py
+++ b/t/unit/test_scheduler_cluster.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""Unit tests for Redis Cluster connection support.
+
+These tests do NOT require a live Redis Cluster -- we mock
+``redis.cluster.RedisCluster`` and only assert that ``RedisScheduler``
+parses the ``rediscluster://`` URL into the right startup nodes / auth
+arguments and dispatches to the cluster client.
+"""
+import unittest
+from unittest.mock import patch, MagicMock
+
+from celery import Celery
+
+from redisbeat import RedisScheduler
+
+
+class TestRedisClusterConnect(unittest.TestCase):
+    def _build_app(self, url):
+        app = Celery('tasks')
+        app.conf.update(CELERY_REDIS_SCHEDULER_URL=url)
+        return app
+
+    def _patched_scheduler(self, url):
+        """Return ``(scheduler, RedisCluster mock, ClusterNode mock)``.
+
+        ``skip_init=True`` prevents ``setup_schedule`` from touching the
+        (mocked) connection, so we can inspect how the URL was parsed.
+        """
+        app = self._build_app(url)
+        with patch('redis.cluster.RedisCluster') as mock_rc, \
+                patch('redis.cluster.ClusterNode') as mock_cn:
+            mock_cn.side_effect = lambda host, port: ('node', host, port)
+            mock_rc.return_value = MagicMock(name='RedisClusterInstance')
+            scheduler = RedisScheduler(app=app, skip_init=True)
+            return scheduler, mock_rc, mock_cn
+
+    def test_single_node_url(self):
+        scheduler, mock_rc, mock_cn = self._patched_scheduler(
+            'rediscluster://localhost:7000')
+
+        mock_cn.assert_called_once_with('localhost', 7000)
+        mock_rc.assert_called_once_with(
+            startup_nodes=[('node', 'localhost', 7000)])
+        self.assertIs(scheduler.rdb, mock_rc.return_value)
+
+    def test_multiple_node_url(self):
+        _, mock_rc, mock_cn = self._patched_scheduler(
+            'rediscluster://host1:7000,host2:7001,host3:7002')
+
+        self.assertEqual(mock_cn.call_args_list, [
+            (('host1', 7000), {}),
+            (('host2', 7001), {}),
+            (('host3', 7002), {}),
+        ])
+        startup_nodes = mock_rc.call_args.kwargs['startup_nodes']
+        self.assertEqual(len(startup_nodes), 3)
+
+    def test_password_only_auth(self):
+        _, mock_rc, _ = self._patched_scheduler(
+            'rediscluster://:secret@host1:7000')
+
+        kwargs = mock_rc.call_args.kwargs
+        self.assertEqual(kwargs.get('password'), 'secret')
+        self.assertNotIn('username', kwargs)
+
+    def test_user_and_password_auth(self):
+        _, mock_rc, _ = self._patched_scheduler(
+            'rediscluster://alice:secret@host1:7000,host2:7001')
+
+        kwargs = mock_rc.call_args.kwargs
+        self.assertEqual(kwargs.get('username'), 'alice')
+        self.assertEqual(kwargs.get('password'), 'secret')
+
+    def test_default_port_when_missing(self):
+        _, _, mock_cn = self._patched_scheduler(
+            'rediscluster://host1,host2:7001')
+
+        # First host: default 6379. Second host: explicit 7001.
+        self.assertEqual(mock_cn.call_args_list, [
+            (('host1', 6379), {}),
+            (('host2', 7001), {}),
+        ])
+
+    def test_db_path_is_ignored(self):
+        # Cluster only supports DB 0; any path component must not surface as
+        # a SELECT / db kwarg.
+        _, mock_rc, _ = self._patched_scheduler(
+            'rediscluster://host1:7000/0')
+
+        kwargs = mock_rc.call_args.kwargs
+        self.assertNotIn('db', kwargs)
+
+    def test_empty_hostspec_raises(self):
+        app = self._build_app('rediscluster://')
+        with patch('redis.cluster.RedisCluster'), \
+                patch('redis.cluster.ClusterNode'):
+            with self.assertRaises(ValueError):
+                RedisScheduler(app=app, skip_init=True)
+
+    def test_non_cluster_url_still_uses_strict_redis(self):
+        """Regression guard: plain ``redis://`` URLs must not hit the cluster
+        path even when redis-py exposes ``RedisCluster``."""
+        app = self._build_app('redis://localhost:6379')
+        with patch('redis.cluster.RedisCluster') as mock_rc, \
+                patch('redisbeat.scheduler.StrictRedis') as mock_strict:
+            RedisScheduler(app=app, skip_init=True)
+            mock_strict.from_url.assert_called_once_with('redis://localhost:6379')
+            mock_rc.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `rediscluster://` URL scheme so `RedisScheduler` connects via `redis.cluster.RedisCluster` instead of `StrictRedis.from_url`, which avoided the `SELECT is not allowed in cluster mode` crash reported in #43.
- Ships `t/unit/test_scheduler_cluster.py` (8 cases) covering URL parsing: single/multi node, password-only and `user:password` auth, default port, db path ignored, empty hostspec error, and a regression guard ensuring plain `redis://` URLs still use `StrictRedis`.
- Adds `example/cluster/` — a docker-compose stack (6-node Bitnami Redis Cluster + standalone redis broker + worker + beat) that demonstrates the fix end-to-end. The broker stays standalone because kombu does not speak the cluster protocol; only the redisbeat schedule lives on the cluster.

## Test plan
- [x] `python -m pytest t/unit/test_scheduler_cluster.py` — 8 passed
- [x] `docker compose -f example/cluster/docker-compose.yml up --build` — bring up the stack and confirm beat no longer crashes with `SELECT is not allowed in cluster mode`
- [x] (Manual) Run `docker compose -f example/cluster/docker-compose.yml run --rm beat python add_task.py` to verify dynamic task registration against the cluster

Fixes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)