### PR TITLE
Fix #42 Bump jsonpickle pin past the broken 3.0.0 release

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -4,7 +4,7 @@ celery==4.3.0
 kombu==4.6.3
 pytz==2019.2
 redis==3.3.8
-jsonpickle==1.4.2
+jsonpickle>=3.3.0
 redisbeat==1.2.6
 vine==1.3.0
 wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,9 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'jsonpickle==3.0.0',
+        # jsonpickle 3.2.0 fixed a regression that crashed decoding of
+        # celery ScheduleEntry payloads on Python 3.11+ (see issue #42).
+        # 3.0.0 / 3.1.0 are known-broken; everything from 3.2.0 works.
+        'jsonpickle>=3.3.0',
     ]
 )

--- a/t/unit/test_codec_roundtrip.py
+++ b/t/unit/test_codec_roundtrip.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""Regression test for issue #42.
+
+jsonpickle <= 3.0.0 cannot round-trip a ``celery.beat.ScheduleEntry``
+(the datetime fields inside crash decode with
+``TypeError: 'NoneType' object is not callable`` on 1.x/2.x or
+``'module' object is not callable`` on 3.0.0). The bug was fixed in
+jsonpickle 3.2.0+, so we just need to require a non-broken version --
+no custom DatetimeHandler is needed.
+
+This test guards against re-pinning to a known-broken version.
+"""
+from datetime import timedelta
+import unittest
+
+from celery import Celery
+from celery.beat import ScheduleEntry
+
+from redisbeat.scheduler import Codec
+
+
+class TestCodecRoundtrip(unittest.TestCase):
+    def test_schedule_entry_roundtrip(self):
+        app = Celery('t')
+        entry = ScheduleEntry(
+            name='perminute',
+            task='tasks.add',
+            schedule=timedelta(seconds=3),
+            args=(1, 1),
+            app=app,
+        )
+
+        codec = Codec()
+        blob = codec.encode(entry)
+        restored = codec.decode(blob)
+
+        self.assertEqual(restored.name, entry.name)
+        self.assertEqual(restored.task, entry.task)
+        # last_run_at must come back as an aware datetime equal to the
+        # original (this is the field that broke under issue #42).
+        self.assertEqual(restored.last_run_at, entry.last_run_at)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `jsonpickle` 1.x / 2.x / 3.0.0 / 3.1.0 all crash when decoding a `celery.beat.ScheduleEntry` (the datetime fields hit `TypeError: 'NoneType' object is not callable` or `'module' object is not callable`). jsonpickle 3.2.0 fixed it upstream, so the custom `DatetimeHandler` workaround proposed in #42 is no longer needed.
- `setup.py` was still pinned to `jsonpickle==3.0.0` — PR #44 only bumped `example/requirements.txt`, missing the install_requires — so any fresh `pip install redisbeat` reintroduced the broken version.
- Bump to `jsonpickle>=3.3.0` in both `setup.py` and `example/requirements.txt`.
- Add `t/unit/test_codec_roundtrip.py` that encode/decodes a `ScheduleEntry` through `Codec`. It fails on the bad pins and passes on 3.2.0+, so future regressions can't slip through silently.

## Verification matrix

Manually swept jsonpickle versions × Python:

| jsonpickle | Py 3.11 | Py 3.13 |
|---|---|---|
| 1.4.2 | ❌ | — |
| 2.0.0 / 2.2.0 | ❌ | — |
| 3.0.0 (old pin) | ❌ | ❌ |
| 3.2.0 | ✓ | ✓ |
| 3.3.0 (new pin) | ✓ | ✓ |

## Test plan
- [x] `python -m pytest t/unit/` — 15 passed locally (Py 3.11, Redis 8 standalone)
- [x] Regression test added in `test_codec_roundtrip.py` — verified red→green by temporarily reinstalling `jsonpickle==3.0.0`

Fixes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)