### PR TITLE
fix: skip undecodable schedule entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ And you can add scheduler task dynamically when you need to add scheduled task.
 
 # Upgrade notes — READ BEFORE UPGRADING
 
-> **redisbeat persists each schedule entry as a `jsonpickle`-serialized `celery.beat.ScheduleEntry` blob.** When the underlying `jsonpickle`, Python, or Celery version changes, the new code may fail to decode blobs written by the old version. The decode loop in `merge_inplace` has no graceful fallback today, so a single undecodable blob can prevent beat from starting.
+> **redisbeat persists each schedule entry as a `jsonpickle`-serialized `celery.beat.ScheduleEntry` blob.** When the underlying `jsonpickle`, Python, or Celery version changes, the new code may fail to decode blobs written by the old version. Older redisbeat releases had no graceful fallback in the decode loops, so a single undecodable blob could prevent beat from starting. Current redisbeat drops undecodable blobs during startup and continues with the remaining schedule entries.
 
 **Pre-upgrade ritual (recommended for any non-trivial version jump):**
 
@@ -30,7 +30,7 @@ redis-cli del celery:beat:order_tasks
 ## Static vs dynamic tasks
 
 - **Static tasks (declared in `CELERYBEAT_SCHEDULE`)** — re-encoded with the *current* `jsonpickle` on every beat startup, with `last_run_at` preserved. **They self-heal across upgrades.**
-- **Dynamic tasks (added at runtime via `RedisScheduler.add(...)`)** — live only in Redis. If the new code can't decode them, beat won't start, and there is no source-of-truth to rebuild from.
+- **Dynamic tasks (added at runtime via `RedisScheduler.add(...)`)** — live only in Redis. If the new code cannot decode them, redisbeat drops those undecodable dynamic entries and continues; there is no source-of-truth to rebuild dropped dynamic entries from.
 
 ## Risk by upgrade path
 
@@ -48,7 +48,7 @@ redis-cli del celery:beat:order_tasks
 redis-cli del celery:beat:order_tasks
 ```
 
-Static tasks from `CELERYBEAT_SCHEDULE` repopulate on the next boot. Dynamic tasks are lost — re-`add()` them.
+Static tasks from `CELERYBEAT_SCHEDULE` repopulate on the next boot. Undecodable dynamic tasks are dropped during startup — re-`add()` them if needed.
 
 
 # Installation

--- a/redisbeat/scheduler.py
+++ b/redisbeat/scheduler.py
@@ -127,6 +127,14 @@ class RedisScheduler(Scheduler):
     def _when(self, entry, next_run_time):
         return mktime(entry.schedule.now().timetuple()) + (self.adjust(next_run_time) or 0)
 
+    def _decode_or_drop(self, task_blob):
+        try:
+            return self.codec.decode(task_blob)
+        except Exception as exc:
+            error("dropping undecodable schedule entry: %s", exc)
+            self.rdb.zrem(self.key, task_blob)
+            return None
+
     def setup_schedule(self):
         debug("setup schedule, skip_init: %s", self.skip_init)
         if self.skip_init:
@@ -142,7 +150,9 @@ class RedisScheduler(Scheduler):
             # str('task: ' + entry.task + '; each: ' + repr(entry.schedule))
             # for entry in entries))
         for entry in entries:
-            decode_task = self.codec.decode(entry)
+            decode_task = self._decode_or_drop(entry)
+            if decode_task is None:
+                continue
             linfo("checking task entry(%s): %s", decode_task.name, decode_task.schedule)
             next_run_interval, new_task = self._calculate_next_run_time_with_init_policy(decode_task)
             next_run_time = self._when(new_task, next_run_interval)
@@ -168,7 +178,9 @@ class RedisScheduler(Scheduler):
             if not task_blob:
                 continue
             debug("ready to load old_entries: %s", task_blob)
-            entry = self.codec.decode(task_blob)
+            entry = self._decode_or_drop(task_blob)
+            if entry is None:
+                continue
             old_entries_dict[entry.name] = (entry, score, task_blob)
         debug("old_entries: %s", old_entries_dict)
 

--- a/t/unit/test_scheduler_decode_errors.py
+++ b/t/unit/test_scheduler_decode_errors.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# encoding: utf-8
+import unittest
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from celery import Celery
+from celery.beat import ScheduleEntry
+
+from redisbeat import RedisScheduler
+
+
+class FailingCodec(object):
+    def decode(self, obj):
+        if isinstance(obj, bytes) and obj == b'bad':
+            raise ValueError('cannot decode')
+        return obj
+
+    def encode(self, obj):
+        return b'encoded:' + obj.name.encode('utf-8')
+
+
+class TestSchedulerDecodeErrors(unittest.TestCase):
+    def _scheduler(self):
+        app = Celery('tasks')
+        app.conf.update(CELERYBEAT_SCHEDULE={})
+        scheduler = RedisScheduler.__new__(RedisScheduler)
+        scheduler.app = app
+        scheduler.Entry = ScheduleEntry
+        scheduler.codec = FailingCodec()
+        scheduler.key = "celery:beat:order_tasks"
+        scheduler.rdb = MagicMock()
+        scheduler._when = lambda entry, next_run_time: 123.0
+        scheduler._calculate_next_run_time_with_init_policy = (
+            lambda entry: (10.0, entry)
+        )
+        scheduler.skip_init = False
+        return scheduler
+
+    def test_merge_inplace_drops_undecodable_entries_and_keeps_valid_tasks(self):
+        scheduler = self._scheduler()
+        old_entry = ScheduleEntry(
+            name='perminute',
+            task='tasks.add',
+            schedule=timedelta(seconds=3),
+            args=(1, 1),
+            app=scheduler.app,
+        )
+        scheduler.rdb.zrangebyscore.return_value = [
+            (b'bad', 1.0),
+            (old_entry, 2.0),
+        ]
+
+        scheduler.merge_inplace({
+            'perminute': {
+                'task': 'tasks.add',
+                'schedule': timedelta(seconds=3),
+                'args': (1, 1),
+            }
+        })
+
+        zrem_args = [call.args for call in scheduler.rdb.zrem.call_args_list]
+        self.assertIn((scheduler.key, b'bad'), zrem_args)
+        self.assertTrue(
+            any(args[0] == scheduler.key and args[1] is old_entry
+                for args in zrem_args)
+        )
+        scheduler.rdb.zadd.assert_called_once()
+
+    def test_setup_schedule_drops_undecodable_entries_and_rewrites_valid_entries(self):
+        scheduler = self._scheduler()
+        good_entry = ScheduleEntry(
+            name='perminute',
+            task='tasks.add',
+            schedule=timedelta(seconds=3),
+            args=(1, 1),
+            app=scheduler.app,
+        )
+        scheduler.rdb.zrange.return_value = [b'bad', good_entry]
+        scheduler.merge_inplace = MagicMock()
+
+        scheduler.setup_schedule()
+
+        zrem_args = [call.args for call in scheduler.rdb.zrem.call_args_list]
+        self.assertIn((scheduler.key, b'bad'), zrem_args)
+        self.assertTrue(
+            any(args[0] == scheduler.key and args[1] is good_entry
+                for args in zrem_args)
+        )
+        scheduler.rdb.zadd.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- drop undecodable persisted schedule entries instead of aborting scheduler startup
- apply the fallback in both startup decode paths (`setup_schedule` and `merge_inplace`)
- update the upgrade notes to document the new behavior

Fixes #50.

## Tests
- `python -m pytest t/unit/test_scheduler_decode_errors.py t/unit/test_codec_roundtrip.py t/unit/test_scheduler_cluster.py -q` — 11 passed
- `python -m py_compile redisbeat/scheduler.py t/unit/test_scheduler_decode_errors.py` — passed
- `git diff --check` — passed

I also checked the new regression tests against the pre-fix scheduler code; they fail before this change because the decode exception aborts `setup_schedule` / `merge_inplace`.

Full `python -m pytest t/unit -q` currently needs a live Redis at `localhost:6379`; without Redis, the existing Redis-backed tests fail with connection refused while the non-Redis subset above passes.

Prepared with AI assistance.
